### PR TITLE
respond_to? → respond_to_missing? (#1)

### DIFF
--- a/lib/liquefied.rb
+++ b/lib/liquefied.rb
@@ -41,7 +41,7 @@ class Liquefied < BasicObject
     @original == other
   end
 
-  def respond_to?(meth, include_all=false)
+  def respond_to_missing?(meth, include_all=false)
     @original.respond_to?(meth, include_all)
   end
 


### PR DESCRIPTION
Using `respond_to?` with ruby-2.4+ break Forwardable module which throws the following error:

```
FILE:LINE: warning: CLASS#METHOD at FILE:LINE forwarding to private method NilClass#METHOD
```

The solution is to upgrade to using `respond_to_missing?` (which was introduced in ruby 1.9.2) instead of relying on `respond_to?`.

The following bog post gives a very good overview of the problem:
- http://blog.marc-andre.ca/2010/11/15/methodmissing-politely/